### PR TITLE
Update node.mdx

### DIFF
--- a/docs/node/node.mdx
+++ b/docs/node/node.mdx
@@ -40,7 +40,7 @@ or
 Run the node:
 
 ```bash
-❯ ./gear --version
+./gear --version
 gear 1.2.1-a218853
 ```
 
@@ -61,7 +61,7 @@ or
 Run the node:
 
 ```bash
-❯ ./gear --version
+./gear --version
 gear 1.2.1-a218853
 ```
 
@@ -81,7 +81,7 @@ or
 Run the node:
 
 ```bash
-❯ ./gear --version
+./gear --version
 gear 1.2.1-a218853
 ```
 
@@ -102,7 +102,7 @@ or
 Unzip the downloaded package, then run the node:
 
 ```bash
-❯ gear.exe --version
+gear.exe --version
 gear.exe 1.2.1-a218853
 ```
 


### PR DESCRIPTION
Docs: Remove prompt symbols from copyable code snippets (❯ ./gear …) to prevent zsh errors